### PR TITLE
Add NX structs from NeXT manual

### DIFF
--- a/WorldWideWeb.xcodeproj/project.pbxproj
+++ b/WorldWideWeb.xcodeproj/project.pbxproj
@@ -113,6 +113,7 @@
 		35DC79272BFAD6AB00432284 /* TextToy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TextToy.m; sourceTree = "<group>"; };
 		35DC79292BFAD6AB00432284 /* HTStyle.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HTStyle.m; sourceTree = "<group>"; };
 		35DC792A2BFAD6AB00432284 /* StyleToy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StyleToy.h; sourceTree = "<group>"; };
+		834673772C796EB4006F7FC0 /* NXShims.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NXShims.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -184,6 +185,7 @@
 				35DC79002BFAD6AA00432284 /* Makefile.preamble */,
 				35DC79132BFAD6AA00432284 /* NewsAccess.h */,
 				35DC79182BFAD6AA00432284 /* NewsAccess.m */,
+				834673772C796EB4006F7FC0 /* NXShims.h */,
 				35DC78ED2BFAD6AA00432284 /* ParseHTML.h */,
 				35DC791B2BFAD6AA00432284 /* PB.gdbinit */,
 				35DC79062BFAD6AA00432284 /* PB.project */,

--- a/WorldWideWeb/HTStyle.h
+++ b/WorldWideWeb/HTStyle.h
@@ -10,6 +10,7 @@
 */
 
 #import <AppKit/AppKit.h>
+#import "NXShims.h"
 
 #define STYLE_NAME_LENGTH 80
 

--- a/WorldWideWeb/HyperText.m
+++ b/WorldWideWeb/HyperText.m
@@ -23,6 +23,7 @@
 #import "HTStyle.h"
 #import "HTUtils.h"
 #import "HyperAccess.h"
+#import "NXShims.h"
 #import "WWW.h"
 #import <AppKit/AppKit.h>
 

--- a/WorldWideWeb/NXShims.h
+++ b/WorldWideWeb/NXShims.h
@@ -8,17 +8,13 @@
 #ifndef NXShims_h
 #define NXShims_h
 
+#import <AppKit/AppKit.h>
+
 /// These are largely just copied from Next Manual
 /// http://www.bitsavers.org/pdf/next/Release_1_Dec90/NEXTstep_Reference_Volume_1_Dec90.pdf
 /// http://www.bitsavers.org/pdf/next/Release_1_Dec90/NEXTstep_Reference_Volume_2_Dec90.pdf
 
-typedef struct NXRect {
-    NXPoint origin;
-    NXSize size;
-} NXRect;
-
-
-typedef struct NXTextBlock {
+typedef struct _NXTextBlock {
     struct _NXTextBlock *next; /* Next block in linked list */
     struct _NXTextBlock *prior; /* Previous block in linked list */
     struct _bFlags {
@@ -32,15 +28,15 @@ typedef struct NXTextBlock {
 /* Describes tabstop. */
 typedef struct _NXTabStop {
     short kind; /* Only NX_LEFTTAB implemented */
-    NXCoord x; /* x coordinate for stop */
+    CGFloat x; /* x coordinate for stop */
 } NXTabStop;
 
 /* Describes text layout and tab stops. */
 typedef struct _NXTextStyle {
-    NXCoord indent1st; /* How far first line in paragraph is */ /* indented */
-    NXCoord indent2nd; /* How far second and subsequent lines */ /* are indented */
-    NXCoord lineHt; /* Line height */
-    NXCoord descentLine; /* Distance from baseline to bottom of line */
+    CGFloat indent1st; /* How far first line in paragraph is */ /* indented */
+    CGFloat indent2nd; /* How far second and subsequent lines */ /* are indented */
+    CGFloat lineHt; /* Line height */
+    CGFloat descentLine; /* Distance from baseline to bottom of line */
     short alignment; /* Text alignment */
     short numTabs; /* Number of tab stops */
     NXTabStop *tabs; /* Array of tab stops */

--- a/WorldWideWeb/NXShims.h
+++ b/WorldWideWeb/NXShims.h
@@ -8,9 +8,6 @@
 #ifndef NXShims_h
 #define NXShims_h
 
-
-#endif /* NXShims_h */
-
 /// These are largely just copied from Next Manual
 /// http://www.bitsavers.org/pdf/next/Release_1_Dec90/NEXTstep_Reference_Volume_1_Dec90.pdf
 /// http://www.bitsavers.org/pdf/next/Release_1_Dec90/NEXTstep_Reference_Volume_2_Dec90.pdf
@@ -83,3 +80,4 @@ typedef struct _NXRunArray {
     NXRun runs[1];
 } NXRunArray;
 
+#endif /* NXShims_h */

--- a/WorldWideWeb/NXShims.h
+++ b/WorldWideWeb/NXShims.h
@@ -1,0 +1,85 @@
+//
+//  NXShims.h
+//  WorldWideWeb
+//
+//  Created by Chris Brandow on 8/23/24.
+//
+
+#ifndef NXShims_h
+#define NXShims_h
+
+
+#endif /* NXShims_h */
+
+/// These are largely just copied from Next Manual
+/// http://www.bitsavers.org/pdf/next/Release_1_Dec90/NEXTstep_Reference_Volume_1_Dec90.pdf
+/// http://www.bitsavers.org/pdf/next/Release_1_Dec90/NEXTstep_Reference_Volume_2_Dec90.pdf
+
+typedef struct NXRect {
+    NXPoint origin;
+    NXSize size;
+} NXRect;
+
+
+typedef struct NXTextBlock {
+    struct _NXTextBlock *next; /* Next block in linked list */
+    struct _NXTextBlock *prior; /* Previous block in linked list */
+    struct _bFlags {
+        unsigned int malloced:1; /* True if block was malloced */
+        unsigned int PAD: 15;
+    } tbFlags;
+    short chars; /* Number of characters in block */
+    unsigned char *text; /* The text */
+} NXTextBlock;
+
+/* Describes tabstop. */
+typedef struct _NXTabStop {
+    short kind; /* Only NX_LEFTTAB implemented */
+    NXCoord x; /* x coordinate for stop */
+} NXTabStop;
+
+/* Describes text layout and tab stops. */
+typedef struct _NXTextStyle {
+    NXCoord indent1st; /* How far first line in paragraph is */ /* indented */
+    NXCoord indent2nd; /* How far second and subsequent lines */ /* are indented */
+    NXCoord lineHt; /* Line height */
+    NXCoord descentLine; /* Distance from baseline to bottom of line */
+    short alignment; /* Text alignment */
+    short numTabs; /* Number of tab stops */
+    NXTabStop *tabs; /* Array of tab stops */
+} NXTextStyle;
+
+typedef struct _NXChunk {
+    short growby; /* Increment to grow by */
+    int allocated; /* Number of bytes allocated */
+    int used; /* Number of bytes used */
+}   NXChunk;
+
+
+typedef struct {
+    unsigned int underline:1; /* True if text is underlined */
+    unsigned int dummy: 1; /* Unused */
+    unsigned int subclassWantsRTF:1; /* Obsolete */
+    unsigned int graphic:1; /* True if graphic is present */
+    unsigned int RESERVED:12;
+} NXRunFlags;
+
+/* NXRun represents a single sequence of text with a given format. */
+typedef struct _NXRun {
+    id font; /* Font id */
+    int chars; /* Number of characters in run */
+    void *paraStyle; /* paragraph style information */
+    float textGray; /* Text gray of current run */
+    float textRGBColor; /* Text color of current run */
+    unsigned char superscript; /* Superscript in points */
+    unsigned char subscript; /* Subscript in points */
+    id info; /* For subclasses of Text */
+    NXRunFlags rFlags; /* Indicates underline etc. */
+} NXRun;
+
+/* An NXRunArray holds the array of text runs.*/
+typedef struct _NXRunArray {
+    NXChunk chunk;
+    NXRun runs[1];
+} NXRunArray;
+


### PR DESCRIPTION
This copies most of the relevant NX structs from the 1990 Nextstep manuals:

http://www.bitsavers.org/pdf/next/Release_1_Dec90/NEXTstep_Reference_Volume_1_Dec90.pdf
http://www.bitsavers.org/pdf/next/Release_1_Dec90/NEXTstep_Reference_Volume_2_Dec90.pdf